### PR TITLE
feat: Implement high score persistence using local storage

### DIFF
--- a/src/flappy-bird.tsx
+++ b/src/flappy-bird.tsx
@@ -16,6 +16,16 @@ export default function FlappyBird() {
   const [score, setScore] = useState(0);
   const [highScore, setHighScore] = useState(0);
   const [pipes, setPipes] = useState<Pipe[]>([]);
+
+  useEffect(() => {
+    const storedHighScore = localStorage.getItem('flappyBirdHighScore');
+    if (storedHighScore) {
+      const parsedHighScore = parseInt(storedHighScore, 10);
+      if (!isNaN(parsedHighScore)) {
+        setHighScore(parsedHighScore);
+      }
+    }
+  }, []);
   
   const GRAVITY = 0.4;
   const JUMP_FORCE = -7;
@@ -42,6 +52,7 @@ export default function FlappyBird() {
     
     if (score > highScore) {
       setHighScore(score);
+      localStorage.setItem('flappyBirdHighScore', score.toString());
     }
   };
   


### PR DESCRIPTION
This commit introduces functionality to save and load the high score in the Flappy Bird game using the browser's local storage.

Changes include:
- Modified `src/flappy-bird.tsx` to load the high score from `localStorage` when the game component mounts.
- Updated the `endGame` function in `src/flappy-bird.tsx` to save the new high score to `localStorage` whenever it is updated.

The high score now persists across browser sessions, enhancing the player experience.